### PR TITLE
#11 tiltfile deploys the umbrella chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
 .DEFAULT_GOAL := help
 
-CLUSTER_NAME:=flam-flam
+KIND_CLUSTER_NAME:=flam-flam
 
+.PHONY: kind-up
+kind-up: ## Create a kind cluster with a local registry
+	@curl -s https://raw.githubusercontent.com/tilt-dev/kind-local/master/kind-with-registry.sh | KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME} bash -
+
+.PHONY: kind-down
+kind-down: ## Tear down a kind cluster with a local registry
+	@curl -s https://raw.githubusercontent.com/tilt-dev/kind-local/master/teardown-kind-with-registry.sh | KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME} bash -
 
 .PHONY: tilt-up
-tilt-up: ## Create a KIND cluster and start Tilt in foreground
-	@kind get clusters | grep -q ${CLUSTER_NAME} || kind create cluster --name ${CLUSTER_NAME}
+tilt-up: kind-up ## Create a KIND cluster via 'kind-up' and start Tilt in foreground
 	@cd tilt && tilt up
 
 .PHONY: tilt-down
 tilt-down: ## Delete kind cluster used for tilt
-	@kind delete cluster --name ${CLUSTER_NAME}
+	@$(MAKE) kind-down
 
 .PHONY: docker-up
 docker-up: ## Start services defined in compose/docker-compose.yaml

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ make docker-up
 ## Tilt
 
 >Note that `Tiltfile` references the helm chart and the docker build path
->locally for now, so please make sure the `dispatcher-service` and
->`helm-charts` repos are pulled at the same level as this repo
->and are up to date.
+>locally, so please make sure the repos below are pulled at the same level as this repo
+>and are up to date:
+> - `dispatcher-service`
+> - `comment-service`
+> - `submission-service` <-- _not yet, but soon_
+> - `helm-charts`
 
 ### Prerequisites
 
@@ -53,3 +56,5 @@ make tilt-up
 This will start tilt in the foreground. Stopping it with Ctrl-c will stop
 Tilt but won't delete the KIND cluster. Run `make tilt-down` to delete
 cluster or just leave it to be reused next time to run `make tilt-up`.
+
+You can of course still run any `tilt` commands (like `tilt up` or `tilt down`) in the `tilt/` folder.

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -23,18 +23,44 @@ k8s_yaml(secret_from_dict("dispatcher-service-secrets", inputs={
     'REDDIT_CLIENT_ID': os.getenv('REDDIT_CLIENT_ID'),
     'REDDIT_CLIENT_SECRET': os.getenv('REDDIT_CLIENT_SECRET')
 }))
-
 # Deploy a PVC for mongodb data
 k8s_yaml("extra-manifests/mongodb-data.yaml")
 k8s_resource(
-  objects=['dispatcher-service-secrets:secret', 'mongodb-data:persistentvolumeclaim'],
-  new_name='extraManifests'
+  new_name='extraManifests',
+  objects=[
+    'dispatcher-service-secrets:secret',
+    'mongodb-data:persistentvolumeclaim'
+  ]
 )
 
 print("> Deploying helm charts")
-# Deploy the flam-flam Helm chart
+# Deploy the flam-flam umbrella Helm chart 
 k8s_yaml(helm(
     '../../helm-charts/charts/flam-flam',
     name="flam-flam",
     values="helm-values/flam-flam.yaml"
 ))
+
+# Assign correct workloads to accounts and configs in the helm chart
+k8s_resource(
+  workload='flam-flam-mongodb',
+  objects=[
+    'flam-flam-mongodb-init-config:configmap',
+    'flam-flam-mongodb:serviceaccount',
+    'flam-flam-mongodb-root:secret',
+    'flam-flam-mongodb-svc:secret'
+  ]
+)
+k8s_resource(
+  workload='flam-flam-dispatcher-service',
+  objects=[
+    'flam-flam-dispatcher-service:configmap',
+    'flam-flam-dispatcher-service:serviceaccount'
+  ]
+)
+k8s_resource(
+  workload='flam-flam-comment-service',
+  objects=[
+    'flam-flam-comment-service:serviceaccount'
+  ]
+)

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -8,6 +8,8 @@ print("""
 -----------------------------------------------------------------
 """.strip())
 
+local_resource("pre-check", cmd="sh pre-check.sh", deps=["pre-check.sh", ".env"])
+
 print("> Loading secrets from .env")
 dotenv(fn="../.env")
 
@@ -49,18 +51,21 @@ k8s_resource(
     'flam-flam-mongodb:serviceaccount',
     'flam-flam-mongodb-root:secret',
     'flam-flam-mongodb-svc:secret'
-  ]
+  ],
+  resource_deps=['pre-check']
 )
 k8s_resource(
   workload='flam-flam-dispatcher-service',
   objects=[
     'flam-flam-dispatcher-service:configmap',
     'flam-flam-dispatcher-service:serviceaccount'
-  ]
+  ],
+  resource_deps=['pre-check']
 )
 k8s_resource(
   workload='flam-flam-comment-service',
   objects=[
     'flam-flam-comment-service:serviceaccount'
-  ]
+  ],
+  resource_deps=['pre-check']
 )

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -1,7 +1,5 @@
 # Load the environment variables from the .env file at the root of the repo
 load('ext://dotenv', 'dotenv')
-dotenv(fn="../.env")
-
 load('ext://secret', 'secret_from_dict')
 
 print("""
@@ -10,20 +8,33 @@ print("""
 -----------------------------------------------------------------
 """.strip())
 
-print("> Building and deploying the dispatcher")
+print("> Loading secrets from .env")
+dotenv(fn="../.env")
 
-# Build the dispatcher image with a custom name
-docker_build('dispatcher-service-tilt:dev', '../../dispatcher-service')
+print("> Building local images")
+# Build the images with a custom name
+docker_build('dispatcher-service:dev', '../../dispatcher-service')
+# docker_build('submission-service:dev', '../../submission-service')
+docker_build('comment-service:dev', '../../comment-service')
 
+print("> Deploying extra manifests")
 # Deploy secrets for the dispatcher
 k8s_yaml(secret_from_dict("dispatcher-service-secrets", inputs={
     'REDDIT_CLIENT_ID': os.getenv('REDDIT_CLIENT_ID'),
     'REDDIT_CLIENT_SECRET': os.getenv('REDDIT_CLIENT_SECRET')
 }))
 
-# Deploy the Helm chart
+# Deploy a PVC for mongodb data
+k8s_yaml("extra-manifests/mongodb-data.yaml")
+k8s_resource(
+  objects=['dispatcher-service-secrets:secret', 'mongodb-data:persistentvolumeclaim'],
+  new_name='extraManifests'
+)
+
+print("> Deploying helm charts")
+# Deploy the flam-flam Helm chart
 k8s_yaml(helm(
-    '../../helm-charts/charts/dispatcher-service',
-    name="dispatcher-service",
-    values="helm-values/dispatcher-service.yaml"
+    '../../helm-charts/charts/flam-flam',
+    name="flam-flam",
+    values="helm-values/flam-flam.yaml"
 ))

--- a/tilt/extra-manifests/mongodb-data.yaml
+++ b/tilt/extra-manifests/mongodb-data.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb-data
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/tilt/helm-values/dispatcher-service.yaml
+++ b/tilt/helm-values/dispatcher-service.yaml
@@ -1,4 +1,0 @@
----
-image:
-  repository: dispatcher-service-tilt
-  tag: dev

--- a/tilt/helm-values/flam-flam.yaml
+++ b/tilt/helm-values/flam-flam.yaml
@@ -1,0 +1,18 @@
+---
+dispatcher-service:
+  secretName: dispatcher-service-secrets
+  image:
+    repository: dispatcher-service
+    tag: dev
+
+comment-service:
+  image:
+    repository: comment-service
+    tag: dev
+
+mongodb:
+  secrets:
+    root:
+      create: true
+    svc:
+      create: true

--- a/tilt/pre-check.sh
+++ b/tilt/pre-check.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+info () {
+    echo "> $1"
+}
+
+warn () {
+    echo "!!! $1"
+}
+
+error () {
+    echo "!!! $1"; exit 1
+}
+
+info "Checking .env is set up correctly..."
+[ -f "../.env" ] && info "Found .env" || error ".env not found. Please copy 'example.env' in this repo and add your reddit secrets to it."
+grep "^REDDIT_CLIENT_ID" ../.env 1> /dev/null || error "REDDIT_CLIENT_ID is not set in .env"
+grep "^REDDIT_CLIENT_SECRET" ../.env 1> /dev/null || error "REDDIT_CLIENT_ID is not set in .env"
+
+info "Checking whether all required repos are here..."
+required_repos="dispatcher-service comment-service submission-service helm-charts"
+for repo in $required_repos; do
+  [ -d "../../$repo" ] && info "$repo: ok" || error "Repository '$repo' doesn't exist at the same level as this repo. Clone it: 'git clone git@github.com:flam-flam/$repo.git'"
+done
+
+info "Building Helm chart dependencies..."
+helm repo add flam-flam https://flam-flam.github.io/helm-charts
+helm dependency build ../../helm-charts/charts/flam-flam


### PR DESCRIPTION
<!-- Write a description here -->
Make the tilefile build all containers locally and deploy them using the umbrella helm chart.

<!-- Which issue is this PR resolving -->
Closes #11

## Changes made
- Reddit secrets are deployed from the .env file
- A PVC for mongodb is created separately in the tiltfile
- Tiltfile deploys the umbrella helm chart using custom values

## Outstanding changes
- [x] Group the workloads so that there isn't anything uncategorized in tilt

Updates after @fratcliffe's testing:
- [x] Use local image registry with KIND
- [x] Make it clear that other repos need to be present locally - or automate it in the makefile
- [x] Check for `.env` and make tilt track it too
- [x] Run `helm repo add flam-flam https://flam-flam.github.io/helm-charts && helm dependency build` in the `helm-charts/flam-flam` before running it all

## Notes for the reviewer
- `make tilt-up` will create a KIND cluster the run `tilt up`
- The PVC uses `storageClassName: standard` because that is the one available in KIND

## Checklist
- [x] Docs updated
