### PR TITLE
flam-flam/helm-charts#30 use mongo service account instead of root

### DIFF
--- a/tilt/helm-values/comment-service.yaml
+++ b/tilt/helm-values/comment-service.yaml
@@ -5,4 +5,4 @@ image:
 mongo:
   server: mongodb
   secret:
-    name: mongodb-root
+    name: mongodb-svc

--- a/tilt/helm-values/submission-service.yaml
+++ b/tilt/helm-values/submission-service.yaml
@@ -5,4 +5,4 @@ image:
 mongo:
   server: mongodb
   secret:
-    name: mongodb-root
+    name: mongodb-svc


### PR DESCRIPTION
Now that the service account for mongodb is fixed (flam-flam/helm-charts#39), use it in the dev stack

<!-- Which issue is this PR resolving -->
Contributes to flam-flam/helm-charts#30 

